### PR TITLE
Snopes Frontend & Librarian Frontend Are Down

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -336,12 +336,6 @@
 		},
 		"lbry": {
 			"frontends": {
-				"librarian": {
-					"name": "Librarian",
-					"embeddable": true,
-					"instanceList": true,
-					"url": "https://codeberg.org/librarian/librarian"
-				},
 				"lbryDesktop": {
 					"name": "LBRY Desktop",
 					"embeddable": false,
@@ -624,26 +618,8 @@
 			"embeddable": false,
 			"url": "https://wikipedia.org"
 		},
-		"snopes": {
-			"frontends": {
-				"suds": {
-					"name": "Suds",
-					"instanceList": true,
-					"url": "https://git.vern.cc/cobra/Suds"
-				}
-			},
-			"targets": [
-				"^https?:\\/{2}(www\\.)?snopes\\.com\\/"
-			],
-			"name": "Snopes",
-			"options": {
-				"enabled": false,
-				"unsupportedUrls": "bypass"
-			},
-			"imageType": "svg",
-			"embeddable": false,
-			"url": "https://www.snopes.com"
-		},
+		
+		}
 		"waybackMachine": {
 			"frontends": {
 				"waybackClassic": {


### PR DESCRIPTION
The Librarian pussied out lol: https://bcow.xyz/posts/archiving-librarian/

Suds been down for quite some time, might remove it for the time being and then re-add it if he's going to come back.

Source code: https://git.vern.cc/cobra/Suds
Wayback Machine: https://web.archive.org/web/20230314215806if_/https://git.vern.cc/cobra/suds