### PR TITLE
Fix "Search LibRedirect" from context menu

### DIFF
--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -36,7 +36,7 @@ browser.webRequest.onBeforeRequest.addListener(
 		let initiator
 		try {
 			if (details.originUrl) initiator = new URL(details.originUrl)
-			else if (details.initiator) initiator = new URL(details.initiator)
+			else if (details.initiator && details.initiator !== "null") initiator = new URL(details.initiator)
 		} catch {
 			return null
 		}


### PR DESCRIPTION
When you try to select a text on a page and click a "Search LibRedirect" on Google Chrome - it does not redirect to the frontend and shows error page.
After an investigation and debug, I saw Chrome passes details.initiator = "null" for such requests.
Handle this case in code and allow redirects.