### PR TITLE
Add web.archive.org as a Reddit frontend

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -419,6 +419,13 @@ function redirect(url, type, initiator, forceRedirection) {
 			}
 			return `${randomInstance}${url.pathname}${url.search}`
 		}
+		case "redditWaybackMachine": {
+			let lookupUrl = url.href;
+			if (['www.reddit.com', 'reddit.com'].includes(url.hostname)) {
+				lookupUrl = `https://old.reddit.com${url.pathname}`
+			}
+			return `https://web.archive.org/web/20230611000000/${lookupUrl}`
+		}
 		case "neuters": {
 			const p = url.pathname
 			if (p.startsWith('/article/') || p.startsWith('/pf/') || p.startsWith('/arc/') || p.startsWith('/resizer/')) {

--- a/src/config.json
+++ b/src/config.json
@@ -193,6 +193,12 @@
 					"instanceList": true,
 					"url": "https://codeberg.org/teddit/teddit",
 					"localhost": true
+				},
+				"redditWaybackMachine": {
+					"name": "Internet Archive",
+					"instanceList": false,
+					"url": "https://web.archive.org",
+					"localhost": false
 				}
 			},
 			"targets": [


### PR DESCRIPTION
This redirects each reddit link to a web.archive.org snapshot from 2023-06-11 or earlier (before the [blackout](https://www.theverge.com/2023/6/12/23755974/reddit-subreddits-going-dark-private-protest-api-changes) started). It will need some tweaking depending on how the situation develops, but it should fix a lot of dead links without giving Reddit any traffic.

I couldn't really find something else like this already in the project so I apologize if it's out of scope but I deemed it to qualify considering the circumstances and the Internet Archive being a libre organization.