### PR TITLE
Fix FreeTube for non-video urls

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -155,7 +155,7 @@ function redirect(url, type, initiator, forceRedirection) {
 			return url.href.replace(/^https?:\/{2}/, "yattee://")
 		}
 		case "freetube": {
-			return `freetube://https://youtu.be${url.pathname}${url.search}`.replace(/watch\?v=/, "")
+			return  'freetube://' + url.href.replace(/^https?:\/{2}/, "https//")
 		}
 		case "poketube": {
 			if (url.pathname.startsWith('/channel')) {

--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -155,7 +155,7 @@ function redirect(url, type, initiator, forceRedirection) {
 			return url.href.replace(/^https?:\/{2}/, "yattee://")
 		}
 		case "freetube": {
-			return  'freetube://' + url.href.replace(/^https?:\/{2}/, "https//")
+			return  'freetube://' + url.href
 		}
 		case "poketube": {
 			if (url.pathname.startsWith('/channel')) {


### PR DESCRIPTION
youtu.be urls are only used for videos so FreeTube was having issues when receiving non video links (as FreeTube assumes that youtu.be is a video)

fixes https://github.com/FreeTubeApp/FreeTube/issues/3846