### PR TITLE
Add redirects from Tumblr blogs to Priviblur

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -572,19 +572,36 @@ function redirect(url, type, initiator, forceRedirection, incognito) {
 			return `${randomInstance}?url=${encodeURIComponent(url.href)}`
 		}
 		case "priviblur": {
-			if (url.hostname.startsWith("blog"))
-				return `${randomInstance}/blog${url.pathname}${url.search}`
+			// www.tumblr.com
+			if (url.hostname === "www.tumblr.com")
+				return `${randomInstance}${url.pathname}${url.search}`;
 
+			// assets.tumblr.com
 			if (url.hostname.startsWith("assets"))
-				return `${randomInstance}/assets${url.pathname}${url.search}`
+				return `${randomInstance}/tblr/assets${url.pathname}${url.search}`;
 
+			// static.tumblr.com
 			if (url.hostname.startsWith("static"))
-				return `${randomInstance}/static${url.pathname}${url.search}`
+				return `${randomInstance}/tblr/static${url.pathname}${url.search}`;
 
-			const reg = /^([0-9]+)\.media\.tumblr\.com/.exec(url.hostname)
+			// *.media.tumblr.com
+			const reg = /^([0-9]+)\.media\.tumblr\.com/.exec(url.hostname);
 			if (reg)
-				return `${randomInstance}/media/${reg[1]}${url.pathname}${url.search}`
-			return `${randomInstance}${url.pathname}${url.search}`
+				return `${randomInstance}/tblr/media/${reg[1]}${url.pathname}${url.search}`;
+
+			// <blog>.tumblr.com
+			const blogregex = /^(www.)?([a-z\d]{1}[a-z\d-]{0,30}[a-z\d]{0,1})\.tumblr\.com/.exec(url.hostname);
+			const blog_name = blogregex[2];
+
+			if (blogregex)
+				// Under the <blog>.tumblr.com domain posts are under a /post path
+				if (url.pathname.startsWith("/post")) {
+					return `${randomInstance}/${blog_name}${url.pathname.slice(5)}${url.search}`;
+				} else {
+					return `${randomInstance}/${blog_name}${url.pathname}${url.search}`;
+				}
+
+			return `${randomInstance}${url.pathname}${url.search}`;
 		}
 		default: {
 			return `${randomInstance}${url.pathname}${url.search}`

--- a/src/config.json
+++ b/src/config.json
@@ -1006,8 +1006,9 @@
 				}
 			},
 			"targets": [
-				"^https?:\\/{2}(media\\.|blog\\.|assets\\.|static\\.)?tumblr\\.com\\/",
-				"^https?:\\/{2}[0-9]+\\.media\\.tumblr\\.com\\/"
+				"^https?:\\/{2}(media\\.|assets\\.|static\\.)?tumblr\\.com\\/",
+				"^https?:\\/{2}[0-9]+\\.media\\.tumblr\\.com\\/",
+				"^https?:\\/{2}(www\\.)?(.*)\\.tumblr.com\\/"
 			],
 			"name": "Tumblr",
 			"options": {


### PR DESCRIPTION
Example URLs:

```
https://staff.tumblr.com/ ----> https://pb.bloat.cat/staff/
https://staff.tumblr.com/post/736071326097440768/hello-tumblr-this-is-a-badges-update ----> https://pb.bloat.cat/staff/736071326097440768/hello-tumblr-this-is-a-badges-update

https://www.staff.tumblr.com ----> https://pb.bloat.cat/staff
```