### PR TITLE
Disable redirection when a link in the YouTube description section is entered

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -496,6 +496,9 @@ function redirect(url, type, initiator, forceRedirection, incognito) {
 				const watch = url.pathname.substring(url.pathname.lastIndexOf('/') + 1)
 				return `${randomInstance}/watch?v=${watch}`
 			}
+			if (url.hostname.endsWith("youtube.com") && url.pathname.startsWith("/redirect?")) {
+				return url.href
+			}
 			return `${randomInstance}${url.pathname}${url.search}`
 		}
 		case "invidiousMusic": {


### PR DESCRIPTION
Problem:
When I browse YouTube on Invidious, I frequently jump back to youtube.com without disabling the extension by clicking "Watch on YouTube" on Invidious page. After that, when I click some link in the description section (it comes in this format usually https://www.youtube.com/redirect?event=.....), the extension cannot handle it correctly and it returns the homepage of Invidious instance instead.