### PR TITLE
anonoverflow: support other StackExchange sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ package-lock.json
 .vscode
 src/pages/options/index.html
 src/pages/popup/popup.html
+pnpm-lock.yaml

--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -309,11 +309,21 @@ function rewrite(url, frontend, randomInstance) {
 				if (threadID) return `${randomInstance}/questions/${threadID[1]}${url.search}`
 				return `${randomInstance}${url.pathname}${url.search}`
 			}
+			if (url.pathname == "/" || url.pathname == "") {
+				// https://stackexchange.com or https://superuser.com
+				return `${randomInstance}${url.pathname}${url.search}`
+			}
 			const regex = url.href.match(/https?:\/{2}(?:([a-zA-Z0-9-]+)\.)?stackexchange\.com\//)
 			if (regex && regex.length > 1) {
 				const subdomain = regex[1]
 				return `${randomInstance}/exchange/${subdomain}${url.pathname}${url.search}`
 			}
+			const notExchangeRegex = url.hostname.match(/(?:[a-zA-Z]+\.)?(?:askubuntu\.com|mathoverflow\.net|serverfault\.com|stackapps\.com|superuser\.com|stackoverflow\.com)/)
+			if (notExchangeRegex) {
+				return `${randomInstance}/exchange/${notExchangeRegex[0]}${url.pathname}${url.search}`
+			}
+			// "Default case"
+			return `${randomInstance}${url.pathname}${url.search}`
 		}
 		case "biblioReads": {
 			return `${randomInstance}${url.pathname}${url.search}`

--- a/src/config.json
+++ b/src/config.json
@@ -663,8 +663,9 @@
 				}
 			},
 			"targets": [
-				"^https?:\\/{2}(www\\.)?stackoverflow\\.com\\/",
-				"^https?:\\/{2}([a-zA-Z0-9-]+\\.)?stackexchange\\.com\\/"
+				"^https?:\\/{2}(www\\.)?([a-zA-Z]+\\.)?stackoverflow\\.com\\/",
+				"^https?:\\/{2}([a-zA-Z0-9-]+\\.)?stackexchange\\.com\\/",
+				"^https?:\\/{2}(www\\.)?([a-zA-Z]+\\.)?(askubuntu\\.com|mathoverflow\\.net|serverfault\\.com|stackapps\\.com|superuser\\.com)\\/"
 			],
 			"name": "Stack Overflow",
 			"options": {


### PR DESCRIPTION
- Stack Overflow regex changed to support other languages like es.stackoverflow.com or ru.stackoverflow.com
- "Home" urls (like `https://tor.stackexchange.com/`) now redirects to home randomInstance
- Support other Stack Exchange sites (like superuser.com or mathoverflow.com)
- Also, added [pnpm](https://pnpm.io) lock file (`pnpm-lock.yaml`) to `.gitignore`