### PR TITLE
anonoverflow: exclude unsupported domains

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -664,7 +664,7 @@
 			},
 			"targets": [
 				"^https?:\\/{2}(www\\.)?([a-zA-Z]+\\.)?stackoverflow\\.com\\/",
-				"^https?:\\/{2}([a-zA-Z0-9-]+\\.)?stackexchange\\.com\\/",
+				"(?!^https?:\\/{2}(api|data|blog)\\.)^https?:\\/{2}([a-zA-Z0-9-]+\\.)stackexchange\\.com\\/",
 				"^https?:\\/{2}(www\\.)?([a-zA-Z]+\\.)?(askubuntu\\.com|mathoverflow\\.net|serverfault\\.com|stackapps\\.com|superuser\\.com)\\/"
 			],
 			"name": "Stack Overflow",


### PR DESCRIPTION
Related to discussion in #750

Removed:
- stackexchange.com - main StackExchange website with contact, about and etc
- api.stackexchange.com - API
- data.stackexchange.com - Data Explorer
- blog.stackexchange.com - Redirects to stackoverflow.blog