### PR TITLE
Add Page Action Setting (icon in URL bar)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -93,6 +93,9 @@
         "message": "Redirect to original",
         "description": "Used in context menus when right clicking on a page/tab"
     },
+    "pageAction": {
+        "message": "Show in Page Action"
+    },
     "redirectLink": {
         "message": "Attempt to redirect",
         "description": "Used in context menus when right clicking on a hyperlink"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,6 +44,17 @@
 			"128": "assets/images/libredirect-128.png"
 		}
 	},
+	"page_action": {
+		"default_title": "__MSG_extensionName__",
+		"browser_style": false,
+		"default_popup": "pages/popup/popup.html",
+		"default_icon": {
+			"16": "assets/images/libredirect-16.png",
+			"32": "assets/images/libredirect-32.png",
+			"48": "assets/images/libredirect-48.png",
+			"128": "assets/images/libredirect-128.png"
+		}
+	},
 	"options_ui": {
 		"page": "pages/options/index.html",
 		"browser_style": false,

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -28,6 +28,13 @@ browser.runtime.onInstalled.addListener(async details => {
 
 let tabIdRedirects = {}
 
+// page action
+browser.tabs.onUpdated.addListener(async (id, changeInfo, tabInfo) => {
+	const { pageAction } = await utils.getOptions()
+	if (!pageAction) return;
+	browser.pageAction.show(tabInfo.id);
+});
+
 // true == Always redirect, false == Never redirect, null/undefined == follow options for services
 browser.webRequest.onBeforeRequest.addListener(
 	details => {

--- a/src/pages/options/widgets/general.js
+++ b/src/pages/options/widgets/general.js
@@ -121,6 +121,11 @@ bookmarksMenuElement.addEventListener('change', async event => {
 		browser.permissions.remove({ permissions: ["bookmarks"] }, r => bookmarksMenuElement.checked = !r)
 })
 
+const pageActionElement = document.getElementById('pageAction')
+pageActionElement.addEventListener('change', event => {
+	setOption('pageAction', 'checkbox', event)
+})
+
 let themeElement = document.getElementById("theme")
 themeElement.addEventListener("change", event => {
 	setOption("theme", "select", event)
@@ -149,6 +154,7 @@ let options = await utils.getOptions()
 themeElement.value = options.theme
 fetchInstancesElement.value = options.fetchInstances
 redirectOnlyInIncognitoElement.checked = options.redirectOnlyInIncognito
+pageActionElement.checked = options.pageAction
 browser.permissions.contains({ permissions: ["bookmarks"] }, r => bookmarksMenuElement.checked = r)
 for (const service in config.services) document.getElementById(service).checked = options.popupServices.includes(service)
 

--- a/src/pages/options/widgets/general.pug
+++ b/src/pages/options/widgets/general.pug
@@ -26,6 +26,10 @@ section(class="block-option" id="general_page")
         input(id='bookmarksMenu' type="checkbox")
 
     div(class="block block-option")
+        label(for='pageAction' data-localise="__MSG_pageAction__") Use Page Action
+        input(id='pageAction' type="checkbox")
+
+    div(class="block block-option")
         label(data-localise="__MSG_excludeFromRedirecting__") Excluded from redirecting
 
     form(id="custom-exceptions-instance-form")


### PR DESCRIPTION
Adds a setting in the general options to enable [the icon in the URL bar](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction) that brings up the same popup as the extension button.

This is a very simple version that enables the button on every page, but we can tune it to only show this icon on libredirect-compatible pages. We can also edit the wording, it is not very user friendly-- but I wonder how we should name something like this.

![image](https://github.com/libredirect/browser_extension/assets/28381193/7cf5375a-474a-4cfd-a4a1-d5d591f6d5c5)
![image](https://github.com/libredirect/browser_extension/assets/28381193/346ee49f-1695-4110-a053-9c2abc52d5c2)
![image](https://github.com/libredirect/browser_extension/assets/28381193/63966efd-4b27-4a91-aeff-181669f09a64)
