### PR TITLE
Fix: sidebar text layouts and font fallbacks for CJK

### DIFF
--- a/src/pages/options_src/App.svelte
+++ b/src/pages/options_src/App.svelte
@@ -110,7 +110,7 @@
     margin: 0;
     padding-top: 50px;
     justify-content: center;
-    font-family: "Inter";
+    font-family: "Inter", sans-serif;
     box-sizing: border-box;
     font-size: 16px;
     background-color: var(--bg-main);

--- a/src/pages/options_src/Sidebar.svelte
+++ b/src/pages/options_src/Sidebar.svelte
@@ -14,7 +14,7 @@
   </a>
   <a href="#services" on:click={() => page.set("services")} style={$page == "services" && "color: var(--active);"}>
     <ServicesIcon class="margin margin_{document.body.dir}" />
-    {browser.i18n.getMessage("general") || "Services"}
+    {browser.i18n.getMessage("services") || "Services"}
   </a>
   <a href="https://libredirect.github.io" target="_blank" rel="noopener noreferrer">
     <AboutIcon class="margin margin_{document.body.dir}" />
@@ -37,6 +37,7 @@
     color: var(--text);
     transition: 0.1s;
     margin: 10px;
+    min-width: max-content;
   }
 
   a:hover {

--- a/src/pages/popup_src/App.svelte
+++ b/src/pages/popup_src/App.svelte
@@ -106,7 +106,7 @@
     margin: 0;
     padding: 10px;
     padding-top: 20px;
-    font-family: "Inter";
+    font-family: "Inter", sans-serif;
     font-size: 16px;
     background-color: var(--bg-main);
     color: var(--text);


### PR DESCRIPTION
This PR is to fix some CJK display problems for Libredirect's Svelte UI:
- Sidebar: CJK texts are squashed and displayed vertically because they are wider than latin charaters. (Added `max-width: max-content` property for this)
- Options and popup pages do not have fallback fonts, which makes CJK texts appear in a serif font that doesn't quite match the default Inter font. (Added `sans-serif` as fallback)
- Fix the translation key for the Service menu.

|Before|After|
|---|---|
|![before this change](https://github.com/user-attachments/assets/d86d217d-193a-4e55-a642-38d59f312969)|![after this change](https://github.com/user-attachments/assets/9048bb75-ed82-43cf-ad94-d8512c8c0857)|