### PR TITLE
Linking the favicon to the local image file

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,7 +48,7 @@
     "search_provider": {
       "name": "__MSG_extensionName__",
       "keyword": "@libredirect",
-      "favicon_url": "https://raw.githubusercontent.com/libredirect/browser_extension/master/src/assets/images/libredirect.svg",
+      "favicon_url": "assets/images/libredirect.svg",
       "search_url": "https://search.libredirect.invalid/?q={searchTerms}",
       "encoding": "UTF-8",
       "is_default": false


### PR DESCRIPTION
Otherwise it's making a request to the Github server every time I open my browser. Which is the only addon that does that.

![1](https://github.com/user-attachments/assets/9eb05b4f-ca88-4487-ba4d-5621c28f2a02)
Link favicon to the local image file