### PR TITLE
Update services.js - replacing bus-hit.me SearXNG instance

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -891,7 +891,7 @@ const defaultInstances = {
   simplyTranslate: ["https://simplytranslate.org"],
   translite: ["https://tl.bloat.cat"],
   mozhi: ["https://mozhi.aryak.me"],
-  searxng: ["https://search.bus-hit.me"],
+  searxng: ["https://nyc1.sx.ggtyler.dev"],
   "4get": ["https://4get.ca"],
   rimgo: ["https://rimgo.vern.cc"],
   hyperpipe: ["https://hyperpipe.surge.sh"],


### PR DESCRIPTION
Austin Huang's free VPS he used for bus-hit.me's services has been taken down unjustifiably by Oracle, and for the time being, his services will no longer be up until he's in a sufficient financial situation.
Source: https://bus-hit.me/ main page