### PR TITLE
Added Skychat support, async for redirect callback

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -240,6 +240,11 @@
     },
     "bluesky": {
       "frontends": {
+        "skychat": {
+          "name": "Skychat",
+          "instanceList": true,
+          "url": "https://github.com/badlogic/skychat"
+        },
         "skyview": {
           "name": "Skyview",
           "instanceList": true,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "manifest_version": 2,
   "browser_specific_settings": {
     "gecko": {

--- a/src/pages/background/background.js
+++ b/src/pages/background/background.js
@@ -22,9 +22,8 @@ browser.runtime.onInstalled.addListener(async details => {
 // true to redirect, false to bypass
 let tabIdRedirects = {}
 
-// true == Always redirect, false == Never redirect, null/undefined == follow options for services
-browser.webRequest.onBeforeRequest.addListener(
-  details => {
+
+async function redirectCallback(details) {
     const old_href = details.url
     const url = new URL(details.url)
     if (new RegExp(/^chrome-extension:\/{2}.*\/instances\/.*.json$/).test(url.href) && details.type == "xmlhttprequest")
@@ -59,7 +58,7 @@ browser.webRequest.onBeforeRequest.addListener(
       return null
     }
 
-    let newUrl = servicesHelper.redirect(
+    let newUrl = await servicesHelper.redirect(
       url,
       details.type,
       originUrl,
@@ -113,7 +112,9 @@ browser.webRequest.onBeforeRequest.addListener(
       return { redirectUrl: newUrl }
     }
     return null
-  },
+  }
+// true == Always redirect, false == Never redirect, null/undefined == follow options for services
+browser.webRequest.onBeforeRequest.addListener(redirectCallback,
   { urls: ["<all_urls>"] },
   ["blocking"]
 )


### PR DESCRIPTION
Hi there! The Bluesky function only supporting the Skyview system made it annoying to browse user pages. So I added Skychat, another project by the same developer.

In order to do so, the rewrite may need to perform a lookup on the DID, starting with DNS and then falling back to the .wellknown/atproto-did format, before failing to the handle. Maybe better to return 'false' instead?

Presently this DNS lookup is being handled by Cloudflare DoH, but can be replaced with anything else. JS doesn't natively support this or it'd be a non-issue. I'm very open to making changes, I just did not have any privacy options for DoH handy quickly.

But as a result, I had to convert the browser.webRequest.onBeforeRequest function callback into an async one, so that fetch could be awaited properly for a response.

Everything else seems fine afterwards as well.