### PR TITLE
Pinterest: redirect subdomains, fix shortlinks, add reverse

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -373,6 +373,8 @@ function rewrite(url, originUrl, frontend, randomInstance, type) {
       return `${randomInstance}${url.pathname}${url.search}`
     case "painterest":
       if (url.hostname == "i.pinimg.com") return `${randomInstance}/_/proxy?url=${encodeURIComponent(url.href)}`
+      const regex = /^\/pin\/[^\/]+/.exec(url.pathname)
+      if (regex) return `${randomInstance}${regex[0]}`
       return `${randomInstance}${url.pathname}${url.search}`
     case "laboratory": {
       let path = url.pathname
@@ -797,6 +799,7 @@ async function reverse(url) {
       case "quora":
       case "twitter":
       case "medium":
+      case "pinterest":
         return `${config.services[service].url}${url.pathname}${url.search}`
       case "fandom": {
         let regex = url.pathname.match(/^\/([a-zA-Z0-9-]+)\/wiki\/(.*)/)

--- a/src/config.json
+++ b/src/config.json
@@ -562,7 +562,7 @@
       },
       "targets": [
         "^https?:\\/{2}i\\.pinimg\\.com",
-        "^https?:\\/{2}(www\\.)?pinterest\\.com"
+        "^https?:\\/{2}((?!api\\.)[a-zA-Z]+\\.)?pinterest\\.com"
       ],
       "options": {
         "enabled": false,


### PR DESCRIPTION
This PR addresses three issues:
1. Country code subdomains like ru.pinterest.com currently aren't redirected
2. pin.it shortlinks redirect to a 404. They expand to api.pinterest.com first so we have to whitelist that, and then to /pin/\<id\>/sent which is what causes the 404 on Painterest's side
3. Reversing the URL was not implemented