### PR TITLE
Utils: Correctly handle the trailing slash in credential embedded URLs

### DIFF
--- a/src/assets/javascripts/utils.js
+++ b/src/assets/javascripts/utils.js
@@ -25,13 +25,15 @@ function getNextInstance(currentInstanceUrl, instances) {
  */
 function protocolHost(url) {
   url.pathname = url.pathname.replace(/\/$/, "")
-  if (url.username && url.password) return `${url.protocol}//${url.username}:${url.password}@${url.host}${url.pathname}`
 
   // workaround
   if (url.pathname == "/TekstoLibre/" && url.host.endsWith("github.io"))
     return `${url.protocol}//${url.host}${url.pathname.slice(0, -1)}`
 
   const pathname = url.pathname != "/" ? url.pathname : ""
+
+  if (url.username && url.password) return `${url.protocol}//${url.username}:${url.password}@${url.host}${pathname}`
+
   return `${url.protocol}//${url.host}${pathname}`
 }
 


### PR DESCRIPTION
This PR allows the use of custom instances with credentials without a trailing slash.
eg: `https://user:pass@mytedditinstance.com/` will be properly parsed into `https://user:pass@mytedditinstance.com`

It echoes to the previous issue reported in #996 which was fixed but not for embebded credential URLs.