### PR TITLE
Add `ytify` as a `YT Music` frontend

### DIFF
--- a/src/assets/javascripts/services.js
+++ b/src/assets/javascripts/services.js
@@ -574,6 +574,7 @@ function rewrite(url, originUrl, frontend, randomInstance, type) {
 
       return `${randomInstance}${url.pathname}${url.search}`
     }
+    case "ytifyMusic":
     case "ytify": {
       if (url.pathname.startsWith("/watch"))
         return `${randomInstance}/?s=${encodeURIComponent(url.searchParams.get("v"))}`
@@ -948,6 +949,7 @@ const defaultInstances = {
   shoelace: ["https://shoelace.mint.lgbt"],
   skunkyArt: ["https://skunky.bloat.cat"],
   ytify: ["https://ytify.pp.ua"],
+  ytifyMusic: ["https://ytify.pp.ua"],
   nerdsForNerds: ["https://nn.vern.cc"],
   ducksForDucks: ["https://ducksforducks.private.coffee"],
   koub: ["https://koub.clovius.club"],

--- a/src/config.json
+++ b/src/config.json
@@ -156,6 +156,12 @@
     },
     "youtubeMusic": {
       "frontends": {
+        "ytifyMusic": {
+          "name": "ytify",
+          "embeddable": false,
+          "instanceList": true,
+          "url": "https://github.com/n-ce/ytify/"
+        },
         "hyperpipe": {
           "name": "Hyperpipe",
           "instanceList": true,


### PR DESCRIPTION
as I was experimenting a bit with the `YouTube` frontends I came across [ytify](https://github.com/n-ce/ytify/) and was very pleasantly surprised how it worked, specially for music.
then I checked the available options for `YT Music` and saw that it wasn't available there.

I mean, `ytify` is more of a `YT Music` frontend than `YouTube` in terms of functionality anyway.

I did some basic testing ([with `YouTube` turned off](https://github.com/libredirect/browser_extension/blob/396550742846e69c5282b64c3122ebc093119ad0/test-conditions.md?plain=1#L14)) and everything seemed to work fine.

would be greatly appreciated if this was included :)